### PR TITLE
feat: add per-prayer offset config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A plugin to get prayer times and useful islamic essentials inside neovim
 - supports hanafi school of thought adjustments
 - supported methods: MWL, ISNA, Egypt, Makkah, Karachi, Tehran, Jafari, France, Russia, Singapore.
 - supports higher latitude adjustment
+- per-prayer minute offsets to fine-tune calculated times
 - lualine integration to display current waqt status
 
 ## 📦 Requriements
@@ -41,14 +42,24 @@ Install the plugin with your preferred package manager
 
 ```lua
 {
-    refresh     = 1,         -- Refresh interval in minutes to update prayer waqt times
-    latitude    = nil,       -- MANDATORY TO BE PROVIDED. Geolocation latitude of the place of calculation
-    longitude   = nil,       -- MANDATORY TO BE PROVIDED. Geolocation longitude of the place of calculation
-    utc_offset  = 0,         -- timezone, default is GMT+0
-    school      = 'hanafi',  -- school of thought
-    method      = 'MWL',     -- calculation method. default is Muslim World League
-    time_format = '12H',     -- time display format: '12H' for 12-hour with AM/PM, '24h' for 24-hour
-    countdown_only = false,  -- show only countdown to next prayer
+    refresh        = 1,        -- Refresh interval in minutes to update prayer waqt times
+    latitude       = nil,      -- MANDATORY TO BE PROVIDED. Geolocation latitude of the place of calculation
+    longitude      = nil,      -- MANDATORY TO BE PROVIDED. Geolocation longitude of the place of calculation
+    utc_offset     = 0,        -- timezone, default is GMT+0
+    school         = 'hanafi', -- school of thought
+    method         = 'MWL',    -- calculation method. default is Muslim World League
+    time_format    = '12H',    -- time display format: '12H' for 12-hour with AM/PM, '24h' for 24-hour
+    countdown_only = false,    -- show only countdown to next prayer
+    offset         = {         -- per-prayer minute offsets to fine-tune calculated times
+        fajr     = 0,          -- negative values subtract, positive values add minutes
+        sunrise  = 0,
+        dhuhr    = 0,
+        asr      = 0,
+        sunset   = 0,
+        maghrib  = 0,
+        isha     = 0,
+        midnight = 0,
+    },
 }
 ```
 ## 🛠️ Setup

--- a/lua/muslim/init.lua
+++ b/lua/muslim/init.lua
@@ -8,6 +8,16 @@ local M = {
 		method         = 'MWL',
 		time_format    = '12H', -- '12H' for 12-hour with AM/PM, '24h' for 24-hour
 		countdown_only = false,
+		offset         = {      -- per-prayer minute offsets (e.g. fajr = -5 subtracts 5 min, isha = 3 adds 3 min)
+			fajr     = 0,
+			sunrise  = 0,
+			dhuhr    = 0,
+			asr      = 0,
+			sunset   = 0,
+			maghrib  = 0,
+			isha     = 0,
+			midnight = 0,
+		},
 		-- api_url    = "https://api.aladhan.com/v1/timings"
 	},
 	prayer_time_text = 'Please wait...',
@@ -46,7 +56,8 @@ M.setup = function(opts)
 		},
 		utc_offset = M.config.utc_offset,
 		asr = M.config.school,
-		method = M.config.method
+		method = M.config.method,
+		offset = M.config.offset,
 	})
 
 	-- First run

--- a/lua/muslim/prayer_calc.lua
+++ b/lua/muslim/prayer_calc.lua
@@ -19,7 +19,7 @@ local M = {
         dhuhr = "0 min",
         asr = "standard",
         high_lats = "night_middle",
-        tune = {},
+        offset = {},
         format = "24h",
         rounding = "nearest",
         utc_offset = 0,                  -- minutes or 'auto'
@@ -176,8 +176,8 @@ local update_times = function(times)
     return times
 end
 
-local tune_times = function(times)
-    local mins = M.config.tune or {}
+local adjust_time_offsets = function(times)
+    local mins = M.config.offset or {}
 
     for k, v in pairs(times) do
         if mins[k] then
@@ -233,7 +233,7 @@ local compute_times = function()
     end
     times = adjust_high_lats(times)
     times = update_times(times)
-    times = tune_times(times)
+    times = adjust_time_offsets(times)
     times = convert_times(times)
     return times
 end

--- a/tests/prayer_calc_spec.lua
+++ b/tests/prayer_calc_spec.lua
@@ -162,6 +162,87 @@ describe("muslim.prayer_calc", function()
     end)
   end)
 
+  describe("offset config", function()
+    it("positive offset delays prayer time", function()
+      local M_base = fresh_module()
+      M_base.setup({ location = { lat = 21.4225, lng = 39.8262 }, utc_offset = 3, method = "MWL" })
+      M_base.utc_time = MECCA_MARCH_3_2026
+      local fajr_base = M_base.get_times().fajr
+
+      local M_off = fresh_module()
+      M_off.setup({ location = { lat = 21.4225, lng = 39.8262 }, utc_offset = 3, method = "MWL", offset = { fajr = 10 } })
+      M_off.utc_time = MECCA_MARCH_3_2026
+      local fajr_off = M_off.get_times().fajr
+
+      assert.are.equal(fajr_base + 10 * 60000, fajr_off)
+    end)
+
+    it("negative offset advances prayer time", function()
+      local M_base = fresh_module()
+      M_base.setup({ location = { lat = 21.4225, lng = 39.8262 }, utc_offset = 3, method = "MWL" })
+      M_base.utc_time = MECCA_MARCH_3_2026
+      local isha_base = M_base.get_times().isha
+
+      local M_off = fresh_module()
+      M_off.setup({ location = { lat = 21.4225, lng = 39.8262 }, utc_offset = 3, method = "MWL", offset = { isha = -5 } })
+      M_off.utc_time = MECCA_MARCH_3_2026
+      local isha_off = M_off.get_times().isha
+
+      assert.are.equal(isha_base - 5 * 60000, isha_off)
+    end)
+
+    it("zero offset leaves prayer time unchanged", function()
+      local M_base = fresh_module()
+      M_base.setup({ location = { lat = 21.4225, lng = 39.8262 }, utc_offset = 3, method = "MWL" })
+      M_base.utc_time = MECCA_MARCH_3_2026
+      local dhuhr_base = M_base.get_times().dhuhr
+
+      local M_off = fresh_module()
+      M_off.setup({ location = { lat = 21.4225, lng = 39.8262 }, utc_offset = 3, method = "MWL", offset = { dhuhr = 0 } })
+      M_off.utc_time = MECCA_MARCH_3_2026
+      local dhuhr_off = M_off.get_times().dhuhr
+
+      assert.are.equal(dhuhr_base, dhuhr_off)
+    end)
+
+    it("offset for one waqt does not affect other waqts", function()
+      local all_waqts = { "fajr", "sunrise", "dhuhr", "asr", "sunset", "maghrib", "isha", "midnight" }
+
+      local M_base = fresh_module()
+      M_base.setup({ location = { lat = 21.4225, lng = 39.8262 }, utc_offset = 3, method = "MWL" })
+      M_base.utc_time = MECCA_MARCH_3_2026
+      local t_base = M_base.get_times()
+
+      local M_off = fresh_module()
+      M_off.setup({ location = { lat = 21.4225, lng = 39.8262 }, utc_offset = 3, method = "MWL", offset = { asr = 7 } })
+      M_off.utc_time = MECCA_MARCH_3_2026
+      local t_off = M_off.get_times()
+
+      assert.are.equal(t_base.asr + 7 * 60000, t_off.asr)
+      for _, k in ipairs(all_waqts) do
+        if k ~= "asr" then
+          assert.are.equal(t_base[k], t_off[k])
+        end
+      end
+    end)
+
+    it("empty offset table leaves all times unchanged", function()
+      local M_base = fresh_module()
+      M_base.setup({ location = { lat = 21.4225, lng = 39.8262 }, utc_offset = 3, method = "MWL" })
+      M_base.utc_time = MECCA_MARCH_3_2026
+      local t_base = M_base.get_times()
+
+      local M_off = fresh_module()
+      M_off.setup({ location = { lat = 21.4225, lng = 39.8262 }, utc_offset = 3, method = "MWL", offset = {} })
+      M_off.utc_time = MECCA_MARCH_3_2026
+      local t_off = M_off.get_times()
+
+      for _, k in ipairs({ "fajr", "sunrise", "dhuhr", "asr", "sunset", "maghrib", "isha", "midnight" }) do
+        assert.are.equal(t_base[k], t_off[k])
+      end
+    end)
+  end)
+
   describe("get_current_waqt structure", function()
     local M, info
 


### PR DESCRIPTION
## Summary

- Adds an `offset` config key to `setup()` allowing users to add or subtract minutes from each calculated prayer time
- Renames `tune` → `offset` throughout `prayer_calc.lua` (internal config key and `tune_times()` → `adjust_time_offsets()`)
- Updates README with the new config option and adds it to the features list
- Adds 4 tests covering positive, negative, zero, and empty offset cases

## Usage

```lua
require("muslim").setup({
  latitude   = 51.5,
  longitude  = -0.1,
  utc_offset = 0,
  offset = {
    fajr    = -5,   -- 5 minutes earlier
    dhuhr   =  6,   -- 6 minutes later
    maghrib =  3,
  },
})
```

re #8